### PR TITLE
Get next issue

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,13 @@
 module.exports = function (api) {
-  api.cache(true);
+  const isTest = api.env("test");
+
   return {
     presets: ["babel-preset-expo"],
     plugins: [
       // Required for expo-router
       "expo-router/babel",
-      "nativewind/babel",
-    ],
+      // Disable NativeWind Babel plugin during tests to avoid async PostCSS errors
+      !isTest && "nativewind/babel",
+    ].filter(Boolean),
   };
 };


### PR DESCRIPTION
Disable NativeWind Babel plugin in the test environment to fix Jest test failures.

The NativeWind Babel plugin caused async PostCSS errors during Jest test runs, leading to test failures. Conditionally disabling it for the test environment resolves this issue and allows tests to pass. A conflicting `api.cache(true)` call was also removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba05f2aa-8523-4a0a-8a80-285bcb666ff7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba05f2aa-8523-4a0a-8a80-285bcb666ff7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

